### PR TITLE
目次と本文のバランス調整

### DIFF
--- a/components/post/post-container.tsx
+++ b/components/post/post-container.tsx
@@ -19,7 +19,7 @@ const PostContainer = ({ post }: Props) => {
           </Head>
           <main className="order-2 xl:order-1 xl:flex-1 xl:min-w-0">
             {/* 1024px の時は max-w-xl がちょうどいいが、今はそれを無視しておく */}
-            <div className="w-full xl:max-w-4xl mx-auto py-6 px-0 sm:px-6 lg:px-10">
+            <div className="w-full xl:max-w-5xl 2xl:max-w-6xl mx-auto py-6 px-0 sm:px-6 lg:px-8 xl:px-10">
               <div className="rounded-lg bg-white shadow-lg overflow-hidden">
                 <div className="p-0 sm:p-6 lg:p-8">
                   <div className="mt-5">


### PR DESCRIPTION
## 概要
- 目次コンテナの固定幅を見直して本文領域を広げました
- 外枠のレイアウトを調整し、本文を中央に寄せました

## テスト
- 未実施