### PR TITLE
[codex] Simplify top page post list

### DIFF
--- a/components/blog-top-page.tsx
+++ b/components/blog-top-page.tsx
@@ -12,10 +12,18 @@ export default function BlogTopPage({ posts }: Props) {
   return (
     <div className="bg-sol-base2 dark:bg-sol-base03 text-sol-base01 dark:text-sol-base1">
       <BlogTitle />
-      <main className="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main className="container mx-auto px-4 py-12 sm:px-6 lg:px-8">
         <section>
-          <h2 className="text-3xl font-bold text-sol-base02 dark:text-sol-base2 mb-8">最新記事</h2>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+          <div className="mb-12">
+            <p className="text-5xl font-bold leading-none text-sol-base02 dark:text-sol-base2 sm:text-6xl">
+              nogtk.dev
+            </p>
+            <p className="mt-4 text-lg text-sol-base00 dark:text-sol-base0">
+              技術のメモと、日々の記録
+            </p>
+          </div>
+          <h2 className="mb-5 text-2xl font-bold text-sol-base02 dark:text-sol-base2">最新記事</h2>
+          <div>
             {recentPosts.map((post) => (
               <PostPreview
                 key={post.slug}
@@ -23,11 +31,9 @@ export default function BlogTopPage({ posts }: Props) {
                 date={post.date}
                 slug={post.slug}
                 excerpt={post.excerpt}
-                coverImage={post.coverImage}
               />
             ))}
           </div>
-
         </section>
       </main>
     </div>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -5,46 +5,30 @@ type Props = {
   date: string;
   excerpt: string;
   slug: string;
-  coverImage?: string;
-  featured?: boolean;
 };
 
-const PostPreview = ({ title, date, excerpt, slug, coverImage, featured }: Props) => {
-  const defaultImage = "https://placehold.co/600x400/E0E7FF/4A5568?text=記事画像";
-  const ogImageUrl = `/assets/og/${slug}.svg`;
-  const imageUrl = ogImageUrl;
-
-  if (featured) {
-    return (
-      <Link href={`/posts/${slug}`} className="block bg-sol-base3 dark:bg-sol-base02 rounded-lg shadow-lg overflow-hidden hover:shadow-xl transition-shadow duration-300">
-        <img src={imageUrl} className="w-full h-64 sm:h-80 md:h-96 object-cover" alt={title} />
-        <div className="p-6">
-          <h3 className="text-2xl font-bold mb-2 text-sol-base02 dark:text-sol-base2 hover:text-sol-blue transition-colors">
+const PostPreview = ({ title, date, excerpt, slug }: Props) => {
+  return (
+    <Link
+      href={`/posts/${slug}`}
+      className="group block border-t border-sol-base1/40 py-7 transition-colors last:border-b hover:border-sol-blue dark:border-sol-base01/50"
+    >
+      <article className="grid gap-3 md:grid-cols-[9rem_1fr_auto] md:items-start md:gap-8">
+        <time className="text-sm font-medium text-sol-base00 dark:text-sol-base0 md:pt-1">
+          {date}
+        </time>
+        <div>
+          <h3 className="text-2xl font-bold leading-snug text-sol-base02 transition-colors group-hover:text-sol-blue dark:text-sol-base2">
             {title}
           </h3>
-          <p className="text-sol-base00 dark:text-sol-base0 text-sm mb-3">{date}</p>
-          <p className="text-sol-base01 dark:text-sol-base1 leading-relaxed">{excerpt}</p>
-          <span className="inline-block mt-4 text-sol-blue hover:text-sol-cyan font-semibold transition-colors">
-            続きを読む &rarr;
-          </span>
+          <p className="mt-3 max-w-3xl text-base leading-relaxed text-sol-base01 dark:text-sol-base1">
+            {excerpt}
+          </p>
         </div>
-      </Link>
-    );
-  }
-
-  return (
-    <Link href={`/posts/${slug}`} className="block bg-sol-base3 dark:bg-sol-base02 rounded-lg shadow-lg overflow-hidden transform hover:scale-105 transition-transform duration-300">
-      <img src={imageUrl} className="w-full h-48 object-cover" alt={title} />
-      <div className="p-6">
-        <h3 className="text-xl font-bold mb-2 text-sol-base02 dark:text-sol-base2 hover:text-sol-blue transition-colors">
-          {title}
-        </h3>
-        <p className="text-sol-base00 dark:text-sol-base0 text-sm mb-3">{date}</p>
-        <p className="text-sol-base01 dark:text-sol-base1 text-sm leading-relaxed mb-4">{excerpt}</p>
-        <span className="text-sol-blue hover:text-sol-cyan font-semibold text-sm transition-colors">
-          続きを読む &rarr;
+        <span className="text-sm font-semibold text-sol-blue transition-transform group-hover:translate-x-1 md:pt-2">
+          読む &rarr;
         </span>
-      </div>
+      </article>
     </Link>
   );
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,7 +13,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
       <DefaultSeo
         titleTemplate = '%s | nogtk.dev'
         defaultTitle = 'nogtk.dev'
-        description = "Tech insights, with a sprinkle of life's adventures"
+        description = "技術のメモと、日々の記録"
         twitter = {{
           cardType: 'summary_large_image',
           site: 'nogtk.dev',
@@ -23,7 +23,7 @@ export default function MyApp({ Component, pageProps }: AppProps) {
           type: 'website',
           url: 'https://nogtk.dev',
           title: 'nogtk.dev',
-          description: "Tech insights, with a sprinkle of life's adventures",
+          description: "技術のメモと、日々の記録",
           locale: 'ja_JP',
           siteName: 'nogtk.dev',
           images: [

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,7 @@ export default function Index({ allPosts }: Props) {
 }
 
 export const getStaticProps = async () => {
-  const allPosts = getAllPosts(["title", "date", "slug", "excerpt", "coverImage"]);
+  const allPosts = getAllPosts(["title", "date", "slug", "excerpt"]);
 
   return {
     props: { allPosts },


### PR DESCRIPTION
## Summary

- Replace the top page tile grid with a simpler text-first article list.
- Remove OGP thumbnails from the index page so the list reads more like a calm blog archive.
- Add the updated tagline, `技術のメモと、日々の記録`, to the top page and shared metadata.

## Validation

- `yarn typecheck`
- `yarn build`

## Notes

Leaving this unmerged so the Firebase preview can be checked first.