### PR TITLE
[codex] Refine article TOC layout

### DIFF
--- a/components/post/post-container.tsx
+++ b/components/post/post-container.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { TableOfContents } from "./toc";
+import { TableOfContents, TocItem } from "./toc";
 import Script from "next/script";
 import PostType from "../../interfaces/post";
 import PostTitle from "./post-title";
@@ -7,41 +7,31 @@ import PostBody from "./post-body";
 
 type Props = {
   post: PostType;
+  tocItems: TocItem[];
 };
 
-const PostContainer = ({ post }: Props) => {
+const PostContainer = ({ post, tocItems }: Props) => {
   return (
     <>
       <article className="flex-grow mb-32 bg-sol-base2 dark:bg-sol-base03 min-h-screen">
-        <div className="flex flex-col xl:flex-row justify-center xl:mx-32">
+        <div className="mx-auto grid w-full max-w-[1180px] grid-cols-1 gap-6 px-4 py-6 sm:px-6 lg:grid-cols-[230px_minmax(0,760px)] lg:items-start lg:justify-center lg:gap-10 lg:px-8 xl:max-w-[1240px]">
           <Head>
             <Script src="https://embed.zenn.studio/js/listen-embed-event.js" />
           </Head>
-          <main className="order-2">
-            {/* 1024px の時は max-w-xl がちょうどいいが、今はそれを無視しておく */}
-            <div className="w-full xl:max-w-4xl mx-auto py-6 px-0 sm:px-6 lg:px-10">
-                <div className="rounded-lg bg-sol-base3 dark:bg-sol-base02 shadow-lg overflow-hidden">
-                  <div className="p-0 sm:p-6 lg:p-8">
-                    <div className="mt-5">
-                      <div className="overflow-hidden shadow rounded-lg">
-                        <div className="p-5">
-                          <PostTitle
-                            title={post.title}
-                            date={post.date}
-                          ></PostTitle>
-                          <PostBody content={post.content}></PostBody>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-          </main>
-          <aside className="w-full xl:w-1/3 order-1 lg:mx-auto">
-            <div className="sticky top-12 xl:mt-12 mx-4 xl:mx-0 xl:mt-12">
-              <TableOfContents />
-            </div>
+          <aside className="hidden lg:sticky lg:top-24 lg:block">
+            <TableOfContents items={tocItems} />
           </aside>
+          <main>
+            <div className="rounded-lg bg-sol-base3 shadow-sm ring-1 ring-sol-base2 dark:bg-sol-base02 dark:ring-sol-base02">
+              <div className="px-5 py-7 sm:px-8 lg:px-10">
+                <PostTitle title={post.title} date={post.date}></PostTitle>
+                <div className="lg:hidden">
+                  <TableOfContents items={tocItems} compact />
+                </div>
+                <PostBody content={post.content}></PostBody>
+              </div>
+            </div>
+          </main>
         </div>
       </article>
     </>

--- a/components/post/toc.tsx
+++ b/components/post/toc.tsx
@@ -1,27 +1,55 @@
-"use client";
-
 import React from "react";
-import { useEffect } from "react";
-import tocbot from "tocbot";
 
-export const TableOfContents: React.FC = () => {
-  useEffect(() => {
-    tocbot.init({
-      tocSelector: ".toc",
-      contentSelector: ".markdown-body",
-      headingSelector: "h2, h3, h4",
-      scrollSmooth: true,
-    });
+export type TocItem = {
+  id: string;
+  text: string;
+  level: number;
+};
 
-    return () => tocbot.destroy();
-  }, []);
+type Props = {
+  items: TocItem[];
+  compact?: boolean;
+};
+
+const TocList = ({ items }: { items: TocItem[] }) => {
+  return (
+    <ol className="space-y-2">
+      {items.map((item) => (
+        <li key={item.id} className={item.level >= 3 ? "pl-4" : undefined}>
+          <a
+            href={`#${item.id}`}
+            className="block border-l-2 border-transparent pl-3 text-sm leading-relaxed text-sol-base00 transition-colors hover:border-sol-blue hover:text-sol-blue dark:text-sol-base0"
+          >
+            {item.text}
+          </a>
+        </li>
+      ))}
+    </ol>
+  );
+};
+
+export const TableOfContents: React.FC<Props> = ({ items, compact = false }) => {
+  if (items.length === 0) {
+    return null;
+  }
+
+  if (compact) {
+    return (
+      <details className="my-8 border-y border-sol-base2 py-4 dark:border-sol-base02">
+        <summary className="cursor-pointer text-base font-bold text-sol-base02 dark:text-sol-base2">
+          目次
+        </summary>
+        <nav className="mt-4" aria-label="目次">
+          <TocList items={items} />
+        </nav>
+      </details>
+    );
+  }
 
   return (
-    <div className="rounded-lg bg-sol-base3 dark:bg-sol-base03 shadow-lg overflow-hidden border border-sol-base2 dark:border-sol-base02">
-      <div className="toc-container p-4 sm:p-6">
-        <div className="text-center text-xl font-semibold mb-4 dark:text-sol-base1">目次</div>
-        <div className="toc" />
-      </div>
-    </div>
+    <nav className="border-l border-sol-base2 py-1 pl-4 dark:border-sol-base02" aria-label="目次">
+      <div className="mb-3 text-sm font-bold text-sol-base02 dark:text-sol-base2">目次</div>
+      <TocList items={items} />
+    </nav>
   );
 };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "next-seo": "^6.6.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tocbot": "^4.30.0",
     "typescript": "^5.7.2",
     "zenn-content-css": "0.5.1",
     "zenn-embed-elements": "0.5.1",

--- a/pages/posts/[slug].tsx
+++ b/pages/posts/[slug].tsx
@@ -3,22 +3,20 @@ import ErrorPage from "next/error";
 import Container from "../../components/container";
 import Layout from "../../components/layout";
 import { getPostBySlug, getAllPosts } from "../../lib/api";
-import PostTitle from "../../components/post/post-fallback";
-import Head from "next/head";
 import markdownHtml from "../../lib/markdownHtml";
 import type PostType from "../../interfaces/post";
 import BlogTitle from "../../components/blog-title";
-import Script from "next/script";
 import { NextSeo } from "next-seo";
-import { TableOfContents } from "../../components/post/toc";
+import type { TocItem } from "../../components/post/toc";
 import PostFallback from "../../components/post/post-fallback";
 import PostContainer from "../../components/post/post-container";
 
 type Props = {
   post: PostType;
+  tocItems: TocItem[];
 };
 
-export default function Post({ post }: Props) {
+export default function Post({ post, tocItems }: Props) {
   const router = useRouter();
   const title = post.title;
   const ogImageUrl = `https://nogtk.dev/assets/og/${post.slug}.png`;
@@ -65,7 +63,7 @@ export default function Post({ post }: Props) {
                 },
               ]}
             />
-            <PostContainer post={post} />
+            <PostContainer post={post} tocItems={tocItems} />
           </>
         )}
       </Container>
@@ -77,6 +75,35 @@ type Params = {
   params: {
     slug: string;
   };
+};
+
+const decodeHtml = (value: string): string => {
+  return value
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+};
+
+const extractTocItems = (html: string): TocItem[] => {
+  const headingRegex = /<h([2-4])\s+[^>]*id="([^"]+)"[^>]*>([\s\S]*?)<\/h\1>/g;
+  const items: TocItem[] = [];
+  let match: RegExpExecArray | null;
+
+  while ((match = headingRegex.exec(html)) !== null) {
+    const [, level, id, content] = match;
+    const text = decodeHtml(content.replace(/<[^>]+>/g, "").trim());
+    if (text) {
+      items.push({
+        id,
+        text,
+        level: Number(level),
+      });
+    }
+  }
+
+  return items;
 };
 
 export async function getStaticProps({ params }: Params) {
@@ -96,6 +123,7 @@ export async function getStaticProps({ params }: Params) {
         ...post,
         content,
       },
+      tocItems: extractTocItems(content),
     },
   };
 }

--- a/styles/index.css
+++ b/styles/index.css
@@ -304,48 +304,6 @@ body {
   }
 }
 
-.toc li {
-    list-style-type: none;
-    margin-bottom: 4px;
-    margin-top: 4px;
-    padding-left: 16px;
-    position: relative;
-}
-
-.toc li::before {
-    content: ''; /* 空の内容を指定 */
-    position: absolute;
-    left: 0;
-    top: 12px;
-    transform: translateY(-50%);
-    width: 8px;
-    height: 8px;
-    border: 2px solid #268bd2;
-    border-radius: 50%; /* 丸形にする */
-    background-color: transparent;
-}
-
-.toc a {
-text-decoration: none;
-color: #657b83;
-transition: color 0.3s ease;
-opacity: 0.6;
-}
-
-.toc a:hover {
-opacity: 1;
-}
-
-.toc a.is-active-link {
-font-weight: bold;
-opacity: 1;
-}
-
-.toc li.is-active-li::before {
-    background-color: #268bd2; /* Solarized blue */
-    border: none; /* 枠線を削除 */
-}
-
 /* ── Dark theme overrides ── */
 [data-theme="dark"] body {
   background-color: #002b36;
@@ -548,13 +506,4 @@ opacity: 1;
 /* Dark: iframe blend mode - multiply は暗背景では不要 */
 [data-theme="dark"] .znc iframe {
   mix-blend-mode: normal;
-}
-
-/* Dark: TOC */
-[data-theme="dark"] .toc a {
-  color: #839496;
-}
-
-[data-theme="dark"] .toc li::before {
-  border-color: #268bd2;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6283,7 +6283,6 @@ __metadata:
     react-dom: "npm:^19.0.0"
     satori: "npm:^0.26.0"
     tailwindcss: "npm:^3.4.19"
-    tocbot: "npm:^4.30.0"
     typescript: "npm:^5.7.2"
     zenn-content-css: "npm:0.5.1"
     zenn-embed-elements: "npm:0.5.1"
@@ -7134,13 +7133,6 @@ __metadata:
   dependencies:
     is-number: "npm:^7.0.0"
   checksum: 10c0/487988b0a19c654ff3e1961b87f471702e708fa8a8dd02a298ef16da7206692e8552a0250e8b3e8759270f62e9d8314616f6da274734d3b558b1fc7b7724e892
-  languageName: node
-  linkType: hard
-
-"tocbot@npm:^4.30.0":
-  version: 4.36.8
-  resolution: "tocbot@npm:4.36.8"
-  checksum: 10c0/c8d75edaa32bbb074cb3e3f4e35d2b6bb09a8be47aa4f335e2152634789ff59080867e45cb9171b6dfab6c0a5daedfc7e5b709e81d2bf1d06b6f22ab1f302fde
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Rebalance article pages with a constrained content column and sticky desktop TOC
- Render the TOC from build-time headings and show it as a compact disclosure on mobile/tablet
- Remove the client-side tocbot dependency and old TOC CSS

## Validation
- yarn typecheck
- yarn build

Preview check requested before merge.