### PR TITLE
[codex] Add article draft PR workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/article-draft.yml
+++ b/.github/ISSUE_TEMPLATE/article-draft.yml
@@ -1,0 +1,56 @@
+name: Article draft
+description: Create a blog article draft from a mobile-friendly form.
+title: "[Article Draft]: "
+labels: ["article-draft"]
+body:
+  - type: input
+    id: title
+    attributes:
+      label: Title
+      description: Blog article title.
+      placeholder: Git worktree 入門
+    validations:
+      required: true
+  - type: input
+    id: slug
+    attributes:
+      label: Slug
+      description: Optional. Use lowercase letters, numbers, and hyphens. If empty, it will be generated from the title.
+      placeholder: git-worktree
+    validations:
+      required: false
+  - type: input
+    id: excerpt
+    attributes:
+      label: Excerpt
+      description: Short description shown in article lists and metadata.
+      placeholder: Git worktree の基本的な使い方メモ
+    validations:
+      required: true
+  - type: input
+    id: tech
+    attributes:
+      label: Tech
+      description: Optional technology tag used by the article.
+      placeholder: git
+    validations:
+      required: false
+  - type: input
+    id: date
+    attributes:
+      label: Date
+      description: Optional. Use YYYY-MM-DD. If empty, GitHub Actions uses today's date.
+      placeholder: "2026-07-04"
+    validations:
+      required: false
+  - type: textarea
+    id: body
+    attributes:
+      label: Body
+      description: Article body in Markdown.
+      placeholder: |
+        ## はじめに
+
+        ここに本文を書く。
+    validations:
+      required: true

--- a/.github/workflows/create-article-draft.yml
+++ b/.github/workflows/create-article-draft.yml
@@ -1,0 +1,54 @@
+name: Create article draft PR
+
+on:
+  issues:
+    types:
+      - opened
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  create_article_draft:
+    if: >-
+      contains(github.event.issue.labels.*.name, 'article-draft') &&
+      (
+        github.event.issue.author_association == 'OWNER' ||
+        github.event.issue.author_association == 'MEMBER' ||
+        github.event.issue.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
+
+      - name: Create article markdown
+        id: draft
+        run: node scripts/create-article-draft.js
+
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Add article draft ${{ steps.draft.outputs.slug }}
+          branch: article-draft/${{ steps.draft.outputs.slug }}
+          delete-branch: true
+          title: Add article draft: ${{ steps.draft.outputs.title }}
+          body: |
+            Created from #${{ github.event.issue.number }}.
+
+            ## Generated file
+            - `${{ steps.draft.outputs.post_path }}`
+
+            Firebase Hosting will create a preview from this PR.
+          labels: article-draft
+
+      - name: Comment with pull request URL
+        if: steps.cpr.outputs.pull-request-url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment "${{ github.event.issue.number }}" --body "Article draft PR created: ${{ steps.cpr.outputs.pull-request-url }}"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "build:static": "npm run generate-og && npm run generate-sitemap && next build",
     "start": "next start",
     "typecheck": "tsc",
+    "test:article-draft": "node --test scripts/create-article-draft.test.js",
     "generate-og": "node scripts/generate-og-images.js",
     "generate-sitemap": "node scripts/generate-sitemap.js"
   },

--- a/scripts/create-article-draft.js
+++ b/scripts/create-article-draft.js
@@ -1,0 +1,158 @@
+const fs = require('fs');
+const path = require('path');
+
+const NO_RESPONSE = '_No response_';
+
+const FIELD_KEYS = {
+  title: 'title',
+  slug: 'slug',
+  excerpt: 'excerpt',
+  tech: 'tech',
+  date: 'date',
+  body: 'body',
+};
+
+const normalizeFieldName = (value) => value.trim().toLowerCase();
+
+const cleanIssueValue = (value) => {
+  const cleaned = value.trim();
+  return cleaned === NO_RESPONSE ? '' : cleaned;
+};
+
+const parseIssueFormBody = (issueBody) => {
+  const fields = {};
+  let currentKey = null;
+  let currentLines = [];
+
+  const flush = () => {
+    if (!currentKey) return;
+    fields[currentKey] = cleanIssueValue(currentLines.join('\n'));
+  };
+
+  for (const line of issueBody.replace(/\r\n/g, '\n').split('\n')) {
+    const heading = line.match(/^###\s+(.+?)\s*$/);
+
+    if (heading) {
+      flush();
+      currentKey = FIELD_KEYS[normalizeFieldName(heading[1])] || null;
+      currentLines = [];
+      continue;
+    }
+
+    if (currentKey) {
+      currentLines.push(line);
+    }
+  }
+
+  flush();
+  return fields;
+};
+
+const sanitizeSlug = (value) => value
+  .toLowerCase()
+  .normalize('NFKD')
+  .replace(/[^a-z0-9]+/g, '-')
+  .replace(/^-+|-+$/g, '');
+
+const generateSlug = (title, requestedSlug, date) => {
+  const requested = sanitizeSlug(requestedSlug || '');
+  if (requested) return requested;
+
+  const fromTitle = sanitizeSlug(title || '');
+  return fromTitle || `${date}-article`;
+};
+
+const escapeFrontmatterString = (value) => JSON.stringify(value || '');
+
+const buildArticleMarkdown = ({ title, excerpt, date, tech, body }) => {
+  const lines = [
+    '---',
+    `title: ${escapeFrontmatterString(title)}`,
+    `excerpt: ${escapeFrontmatterString(excerpt)}`,
+    `date: ${escapeFrontmatterString(date)}`,
+  ];
+
+  if (tech) {
+    lines.push(`tech: ${escapeFrontmatterString(tech)}`);
+  }
+
+  lines.push('---', '', body.trim(), '');
+  return lines.join('\n');
+};
+
+const normalizeDate = (value) => {
+  if (value) return value;
+  return new Date().toISOString().slice(0, 10);
+};
+
+const requireField = (fields, key) => {
+  if (!fields[key]) {
+    throw new Error(`Missing required issue form field: ${key}`);
+  }
+};
+
+const appendGitHubOutput = (outputs) => {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) return;
+
+  const lines = Object.entries(outputs).map(([key, value]) => `${key}=${value}`);
+  fs.appendFileSync(outputPath, `${lines.join('\n')}\n`);
+};
+
+const createArticleDraft = ({ eventPath, cwd = process.cwd() }) => {
+  const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+  const fields = parseIssueFormBody(event.issue.body || '');
+
+  requireField(fields, 'title');
+  requireField(fields, 'excerpt');
+  requireField(fields, 'body');
+
+  const date = normalizeDate(fields.date);
+  const slug = generateSlug(fields.title, fields.slug, date);
+  const postPath = path.join(cwd, '_posts', `${slug}.md`);
+
+  if (fs.existsSync(postPath)) {
+    throw new Error(`Post already exists: _posts/${slug}.md`);
+  }
+
+  const markdown = buildArticleMarkdown({
+    title: fields.title,
+    excerpt: fields.excerpt,
+    date,
+    tech: fields.tech,
+    body: fields.body,
+  });
+
+  fs.writeFileSync(postPath, markdown);
+
+  const outputs = {
+    slug,
+    title: fields.title,
+    post_path: `_posts/${slug}.md`,
+  };
+  appendGitHubOutput(outputs);
+
+  return outputs;
+};
+
+if (require.main === module) {
+  try {
+    const eventPath = process.env.GITHUB_EVENT_PATH;
+    if (!eventPath) {
+      throw new Error('GITHUB_EVENT_PATH is required');
+    }
+
+    const outputs = createArticleDraft({ eventPath });
+    console.log(`Created ${outputs.post_path}`);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  buildArticleMarkdown,
+  createArticleDraft,
+  generateSlug,
+  parseIssueFormBody,
+};

--- a/scripts/create-article-draft.test.js
+++ b/scripts/create-article-draft.test.js
@@ -1,0 +1,81 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildArticleMarkdown,
+  generateSlug,
+  parseIssueFormBody,
+} = require('./create-article-draft');
+
+test('generateSlug uses a sanitized requested slug when provided', () => {
+  assert.equal(generateSlug('Ignored title', ' Try Jujutsu!! ', '2026-07-04'), 'try-jujutsu');
+});
+
+test('generateSlug extracts english words from title when slug is empty', () => {
+  assert.equal(generateSlug('Git worktree 入門', '', '2026-07-04'), 'git-worktree');
+});
+
+test('generateSlug falls back to date based slug for japanese-only title', () => {
+  assert.equal(generateSlug('記事を書く', '', '2026-07-04'), '2026-07-04-article');
+});
+
+test('parseIssueFormBody reads GitHub Issue Form sections', () => {
+  const body = [
+    '### Title',
+    '',
+    'Git worktree 入門',
+    '',
+    '### Slug',
+    '',
+    '_No response_',
+    '',
+    '### Excerpt',
+    '',
+    'スマホから書くテスト',
+    '',
+    '### Tech',
+    '',
+    'git',
+    '',
+    '### Body',
+    '',
+    '## はじめに',
+    '',
+    '本文です。',
+  ].join('\n');
+
+  assert.deepEqual(parseIssueFormBody(body), {
+    title: 'Git worktree 入門',
+    slug: '',
+    excerpt: 'スマホから書くテスト',
+    tech: 'git',
+    body: '## はじめに\n\n本文です。',
+  });
+});
+
+test('buildArticleMarkdown creates frontmatter and body', () => {
+  const markdown = buildArticleMarkdown({
+    title: 'Git worktree 入門',
+    excerpt: 'スマホから書くテスト',
+    date: '2026-07-04',
+    tech: 'git',
+    body: '## はじめに\n\n本文です。',
+  });
+
+  assert.equal(
+    markdown,
+    [
+      '---',
+      'title: "Git worktree 入門"',
+      'excerpt: "スマホから書くテスト"',
+      'date: "2026-07-04"',
+      'tech: "git"',
+      '---',
+      '',
+      '## はじめに',
+      '',
+      '本文です。',
+      '',
+    ].join('\n'),
+  );
+});


### PR DESCRIPTION
## Summary
- add a mobile-friendly Issue Form for article drafts
- add a GitHub Actions workflow that turns article draft issues into pull requests
- add a Node.js draft generator with slug generation and tests

## Details
The draft generator prefers an explicitly entered slug, falls back to sanitized English words from the title, and uses a date-based slug when no usable slug can be derived. Existing post filename collisions fail the workflow instead of silently changing the URL.

## Verification
- `PATH=/opt/homebrew/bin:/usr/bin:/bin /opt/homebrew/bin/yarn test:article-draft`
- `PATH=/opt/homebrew/bin:/usr/bin:/bin /opt/homebrew/bin/yarn build`

Note: the local `gh` token is currently invalid, so this PR was created through the GitHub connector instead of the GitHub CLI.